### PR TITLE
debug: release check from fork

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   release-check:
-    uses: protocol/.github/.github/workflows/release-check.yml@master
+    uses: protocol/.github/.github/workflows/release-check.yml@fork-release-check

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.3.1"
+  "version": "v0.4.0"
 }


### PR DESCRIPTION
### Copied from https://github.com/libp2p/go-doh-resolver/actions/runs/1592009640

Suggested version: `v0.4.0`
Comparing to: [`v0.3.1`](https://github.com/libp2p/go-doh-resolver/releases/tag/v0.3.1) ([diff](https://github.com/libp2p/go-doh-resolver/compare/v0.3.1..galargh:fork-release-check))

Changes in `go.mod` file(s):
```diff
diff --git a/go.mod b/go.mod
index 6ea06e0..627a9ae 100644
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/libp2p/go-doh-resolver
 
-go 1.15
+go 1.16
 
 require (
 	github.com/ipfs/go-log/v2 v2.1.3
```

`gorelease` says:
```
# github.com/libp2p/go-doh-resolver
## incompatible changes
NewResolver: changed from func(string) *Resolver to func(string, ...Option) (*Resolver, error)
## compatible changes
Option: added
WithCacheDisabled: added
WithMaxCacheTTL: added

# summary
Suggested version: v0.4.0
```

`gocompat` says:
```
(empty)
```