### PR TITLE
feat: allow localhost http endpoints

### DIFF
--- a/resolver.go
+++ b/resolver.go
@@ -2,6 +2,7 @@ package doh
 
 import (
 	"context"
+	"errors"
 	"math"
 	"net"
 	"strings"
@@ -52,7 +53,14 @@ func WithCacheDisabled() Option {
 }
 
 func NewResolver(url string, opts ...Option) (*Resolver, error) {
-	if !strings.HasPrefix(url, "https:") && !strings.HasPrefix(url, "http:") {
+	if strings.HasPrefix(url, "http:") &&
+		!strings.HasPrefix(url, "http://localhost") &&
+		!strings.HasPrefix(url, "http://127.0.0.1") &&
+		!strings.HasPrefix(url, "http://[::1]") {
+		return nil, errors.New("insecure URL: non-local DoH resolvers must use HTTPS")
+	}
+
+	if !strings.HasPrefix(url, "http:") && !strings.HasPrefix(url, "https:") {
 		url = "https://" + url
 	}
 

--- a/resolver.go
+++ b/resolver.go
@@ -52,7 +52,7 @@ func WithCacheDisabled() Option {
 }
 
 func NewResolver(url string, opts ...Option) (*Resolver, error) {
-	if !strings.HasPrefix(url, "https:") {
+	if !strings.HasPrefix(url, "https:") && !strings.HasPrefix(url, "http:") {
 		url = "https://" + url
 	}
 

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -124,11 +124,10 @@ func TestLookupTXT(t *testing.T) {
 	})
 	defer resolver.Close()
 
-	r, err := NewResolver("")
+	r, err := NewResolver(resolver.URL)
 	if err != nil {
 		t.Fatal("resolver cannot be initialised")
 	}
-	r.url = resolver.URL
 
 	txt, err := r.LookupTXT(context.Background(), domain)
 	if err != nil {
@@ -156,11 +155,10 @@ func TestLookupCache(t *testing.T) {
 	defer resolver.Close()
 
 	const cacheTTL = time.Second
-	r, err := NewResolver("", WithMaxCacheTTL(cacheTTL))
+	r, err := NewResolver(resolver.URL, WithMaxCacheTTL(cacheTTL))
 	if err != nil {
 		t.Fatal("resolver cannot be initialised")
 	}
-	r.url = resolver.URL
 
 	txt, err := r.LookupTXT(context.Background(), domain)
 	if err != nil {

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -188,6 +188,34 @@ func TestLookupCache(t *testing.T) {
 	}
 }
 
+func TestCleartextRemoteEndpoint(t *testing.T) {
+	// use remote endpoint over http and not https
+	_, err := NewResolver("http://cloudflare-dns.com/dns-query")
+	if err == nil {
+		t.Fatal("using remote DoH endpoint over unencrypted http:// expected should produce error, but expected error was not returned")
+	}
+}
+
+func TestCleartextLocalhostEndpoint(t *testing.T) {
+	testCases := []struct{ hostname string }{
+		{hostname: "localhost"},
+		{hostname: "localhost:8080"},
+		{hostname: "127.0.0.1"},
+		{hostname: "127.0.0.1:8080"},
+		{hostname: "[::1]"},
+		{hostname: "[::1]:8080"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.hostname, func(t *testing.T) {
+			// use local endpoint over http and not https
+			_, err := NewResolver("http://" + tc.hostname + "/dns-query")
+			if err != nil {
+				t.Fatalf("using %q DoH endpoint over unencrypted http:// expected to work, but unexpected error was returned instead", tc.hostname)
+			}
+		})
+	}
+}
+
 func sameIPs(a, b []net.IPAddr) bool {
 	if len(a) != len(b) {
 		return false


### PR DESCRIPTION
Allows using HTTP in addition to HTTPS as a DNS endpoint. This makes self-hosting DNS resolvers much easier as there's no need to get a domain name, TLS certs from a CA, etc. One particular example of this is making it easier for folks to self-host local non-ICANN resolvers such as for ENS, Handshake, OpenNIC, etc.

Related to https://github.com/ipfs/boxo/pull/645