### PR TITLE
fix: include url on HTTP error

### DIFF
--- a/request.go
+++ b/request.go
@@ -42,7 +42,7 @@ func doRequest(ctx context.Context, url string, m *dns.Msg) (*dns.Msg, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("HTTP error: %q [%d]", resp.Status, resp.StatusCode)
+		return nil, fmt.Errorf("HTTP error: %q [%d] from %q", resp.Status, resp.StatusCode, url)
 	}
 
 	if ct := resp.Header.Get("Content-Type"); ct != dohMimeType {


### PR DESCRIPTION
End user applications built with this library have per TLD DoH resolvers  ([example](https://github.com/ipfs/kubo/blob/master/docs/config.md#dnsresolvers)).

Including the URL of DoH endpoint helps end user to self-service when one of DoH resolvers goes down (example: https://github.com/ipfs/boxo/issues/772)


## Demo

Let's assume `https://example.com/dns-query` responsible for resolving `.test` TLD is down.

Without this PR, user gets confusing error:

```console
$ curl http://this-fails.test.ipns.localhost:8088/
failed to resolve /ipns/this-fails.test/: DNSLink lookup for "this-fails.test." failed: HTTP error: "405 Method Not Allowed" [405
```

With this PR, end user gets meaningful error `HTTP error: "405 Method Not Allowed" [405] from "https://example.com/dns-query"`

```console
$ curl http://test.crypto.ipns.localhost:8090/
failed to resolve /ipns/this-fails.test/: DNSLink lookup for "this-fails.test." failed: HTTP error: "405 Method Not Allowed" [405] from "https://example.com/dns-query"
```