### PR TITLE
feat: add LookupTXTWithTTL to expose TXT record TTL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25
 require (
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/miekg/dns v1.1.62
-	github.com/multiformats/go-multiaddr-dns v0.4.1
+	github.com/multiformats/go-multiaddr-dns v0.6.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/libp2p/go-doh-resolver
 
-go 1.24
+go 1.25
 
 require (
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/miekg/dns v1.1.62
-	github.com/multiformats/go-multiaddr-dns v0.4.1
+	github.com/multiformats/go-multiaddr-dns v0.6.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/libp2p/go-doh-resolver
 
-go 1.25
+go 1.24
 
 require (
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/miekg/dns v1.1.62
-	github.com/multiformats/go-multiaddr-dns v0.6.0
+	github.com/multiformats/go-multiaddr-dns v0.4.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/multiformats/go-base36 v0.2.0 h1:lFsAbNOGeKtuKozrtBsAkSVhv1p9D0/qedU9
 github.com/multiformats/go-base36 v0.2.0/go.mod h1:qvnKE++v+2MWCfePClUEjE78Z7P2a1UV0xHgWc0hkp4=
 github.com/multiformats/go-multiaddr v0.13.0 h1:BCBzs61E3AGHcYYTv8dqRH43ZfyrqM8RXVPT8t13tLQ=
 github.com/multiformats/go-multiaddr v0.13.0/go.mod h1:sBXrNzucqkFJhvKOiwwLyqamGa/P5EIXNPLovyhQCII=
-github.com/multiformats/go-multiaddr-dns v0.6.0 h1:yKIW08WJHSPJ8bDAT2O/5fypCaUu9Bjl8r/1eJ4XAW8=
-github.com/multiformats/go-multiaddr-dns v0.6.0/go.mod h1:dwIQwdORZfnNQCeS7xLXyn+7626oRmMsVP30Uronhf0=
+github.com/multiformats/go-multiaddr-dns v0.4.1 h1:whi/uCLbDS3mSEUMb1MsoT4uzUeZB0N32yzufqS0i5M=
+github.com/multiformats/go-multiaddr-dns v0.4.1/go.mod h1:7hfthtB4E4pQwirrz+J0CcDUfbWzTqEzVyYKKIKpgkc=
 github.com/multiformats/go-multibase v0.0.3/go.mod h1:5+1R4eQrT3PkYZ24C3W2Ue2tPwIdYQD509ZjSb5y9Oc=
 github.com/multiformats/go-multibase v0.2.0 h1:isdYCVLvksgWlMW9OZRYJEa9pZETFivncJHmHnnd87g=
 github.com/multiformats/go-multibase v0.2.0/go.mod h1:bFBZX4lKCA/2lyOFSAoKH5SS6oPyjtnzK/XTFDPkNuk=

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/multiformats/go-base36 v0.2.0 h1:lFsAbNOGeKtuKozrtBsAkSVhv1p9D0/qedU9
 github.com/multiformats/go-base36 v0.2.0/go.mod h1:qvnKE++v+2MWCfePClUEjE78Z7P2a1UV0xHgWc0hkp4=
 github.com/multiformats/go-multiaddr v0.13.0 h1:BCBzs61E3AGHcYYTv8dqRH43ZfyrqM8RXVPT8t13tLQ=
 github.com/multiformats/go-multiaddr v0.13.0/go.mod h1:sBXrNzucqkFJhvKOiwwLyqamGa/P5EIXNPLovyhQCII=
-github.com/multiformats/go-multiaddr-dns v0.4.1 h1:whi/uCLbDS3mSEUMb1MsoT4uzUeZB0N32yzufqS0i5M=
-github.com/multiformats/go-multiaddr-dns v0.4.1/go.mod h1:7hfthtB4E4pQwirrz+J0CcDUfbWzTqEzVyYKKIKpgkc=
+github.com/multiformats/go-multiaddr-dns v0.6.0 h1:yKIW08WJHSPJ8bDAT2O/5fypCaUu9Bjl8r/1eJ4XAW8=
+github.com/multiformats/go-multiaddr-dns v0.6.0/go.mod h1:dwIQwdORZfnNQCeS7xLXyn+7626oRmMsVP30Uronhf0=
 github.com/multiformats/go-multibase v0.0.3/go.mod h1:5+1R4eQrT3PkYZ24C3W2Ue2tPwIdYQD509ZjSb5y9Oc=
 github.com/multiformats/go-multibase v0.2.0 h1:isdYCVLvksgWlMW9OZRYJEa9pZETFivncJHmHnnd87g=
 github.com/multiformats/go-multibase v0.2.0/go.mod h1:bFBZX4lKCA/2lyOFSAoKH5SS6oPyjtnzK/XTFDPkNuk=

--- a/request.go
+++ b/request.go
@@ -75,12 +75,16 @@ func doRequestA(ctx context.Context, url string, domain string) ([]net.IPAddr, u
 
 	var ttl uint32
 	result := make([]net.IPAddr, 0, len(r.Answer))
+	first := true
 	for _, rr := range r.Answer {
 		switch v := rr.(type) {
 		case *dns.A:
 			result = append(result, net.IPAddr{IP: v.A})
-			if ttl == 0 || v.Hdr.Ttl < ttl {
+			// RFC 2181 wants differing TTLs in an RRset treated as the lowest
+			// one; a genuine TTL of 0 must not be mistaken for unset.
+			if first || v.Hdr.Ttl < ttl {
 				ttl = v.Hdr.Ttl
+				first = false
 			}
 		default:
 			log.Warnf("unexpected DNS resource record %+v", rr)
@@ -103,12 +107,14 @@ func doRequestAAAA(ctx context.Context, url string, domain string) ([]net.IPAddr
 
 	var ttl uint32
 	result := make([]net.IPAddr, 0, len(r.Answer))
+	first := true
 	for _, rr := range r.Answer {
 		switch v := rr.(type) {
 		case *dns.AAAA:
 			result = append(result, net.IPAddr{IP: v.AAAA})
-			if ttl == 0 || v.Hdr.Ttl < ttl {
+			if first || v.Hdr.Ttl < ttl {
 				ttl = v.Hdr.Ttl
+				first = false
 			}
 
 		default:

--- a/request.go
+++ b/request.go
@@ -132,12 +132,14 @@ func doRequestTXT(ctx context.Context, url string, domain string) ([]string, uin
 
 	var ttl uint32
 	var result []string
+	first := true
 	for _, rr := range r.Answer {
 		switch v := rr.(type) {
 		case *dns.TXT:
 			result = append(result, v.Txt...)
-			if ttl == 0 || v.Hdr.Ttl < ttl {
+			if first || v.Hdr.Ttl < ttl {
 				ttl = v.Hdr.Ttl
+				first = false
 			}
 
 		default:

--- a/resolver.go
+++ b/resolver.go
@@ -82,11 +82,6 @@ func NewResolver(url string, opts ...Option) (*Resolver, error) {
 
 var _ madns.BasicResolver = (*Resolver)(nil)
 
-// Consumers detect TXT TTL support through this optional interface at runtime,
-// so a signature drift would silently disable TTL reporting downstream; the
-// assertion makes it a compile error instead.
-var _ madns.TXTWithTTLResolver = (*Resolver)(nil)
-
 func (r *Resolver) LookupIPAddr(ctx context.Context, domain string) (result []net.IPAddr, err error) {
 	result, ok := r.getCachedIPAddr(domain)
 	if ok {

--- a/resolver.go
+++ b/resolver.go
@@ -124,19 +124,29 @@ func (r *Resolver) LookupIPAddr(ctx context.Context, domain string) (result []ne
 }
 
 func (r *Resolver) LookupTXT(ctx context.Context, domain string) ([]string, error) {
-	result, ok := r.getCachedTXT(domain)
-	if ok {
-		return result, nil
+	result, _, err := r.LookupTXTWithTTL(ctx, domain)
+	return result, err
+}
+
+// LookupTXTWithTTL is like [Resolver.LookupTXT] but also returns how long the
+// TXT records may be cached. The TTL is the smallest Ttl across the answer's
+// TXT resource records, capped by the resolver's max cache TTL. On a cache hit
+// it is the remaining lifetime of the cached entry, so the value shrinks as the
+// entry ages. A TTL of 0 means the TTL is unknown, for example when the
+// upstream resolver does not provide one.
+func (r *Resolver) LookupTXTWithTTL(ctx context.Context, domain string) ([]string, time.Duration, error) {
+	if result, ttl, ok := r.getCachedTXTWithTTL(domain); ok {
+		return result, ttl, nil
 	}
 
 	result, ttl, err := doRequestTXT(ctx, r.url, domain)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	cacheTTL := minTTL(time.Duration(ttl)*time.Second, r.maxCacheTTL)
 	r.cacheTXT(domain, result, cacheTTL)
-	return result, nil
+	return result, cacheTTL, nil
 }
 
 func (r *Resolver) getCachedIPAddr(domain string) ([]net.IPAddr, bool) {
@@ -170,21 +180,26 @@ func (r *Resolver) cacheIPAddr(domain string, ips []net.IPAddr, ttl time.Duratio
 }
 
 func (r *Resolver) getCachedTXT(domain string) ([]string, bool) {
+	txt, _, ok := r.getCachedTXTWithTTL(domain)
+	return txt, ok
+}
+
+func (r *Resolver) getCachedTXTWithTTL(domain string) ([]string, time.Duration, bool) {
 	r.mx.Lock()
 	defer r.mx.Unlock()
 
 	fqdn := dns.Fqdn(domain)
 	entry, ok := r.txtCache[fqdn]
 	if !ok {
-		return nil, false
+		return nil, 0, false
 	}
 
 	if time.Now().After(entry.expire) {
 		delete(r.txtCache, fqdn)
-		return nil, false
+		return nil, 0, false
 	}
 
-	return entry.txt, true
+	return entry.txt, time.Until(entry.expire), true
 }
 
 func (r *Resolver) cacheTXT(domain string, txt []string, ttl time.Duration) {

--- a/resolver.go
+++ b/resolver.go
@@ -37,10 +37,10 @@ type txtEntry struct {
 type Option func(*Resolver) error
 
 // Specifies the maximum time entries are valid in the cache
-// A maxCacheTTL of zero is equivalent to `WithCacheDisabled`
+// A maxCacheTTL of zero or less is equivalent to `WithCacheDisabled`
 func WithMaxCacheTTL(maxCacheTTL time.Duration) Option {
 	return func(tr *Resolver) error {
-		tr.maxCacheTTL = maxCacheTTL
+		tr.maxCacheTTL = max(0, maxCacheTTL)
 		return nil
 	}
 }
@@ -130,10 +130,11 @@ func (r *Resolver) LookupTXT(ctx context.Context, domain string) ([]string, erro
 
 // LookupTXTWithTTL is like [Resolver.LookupTXT] but also returns how long the
 // TXT records may be cached. The TTL is the smallest Ttl across the answer's
-// TXT resource records, capped by the resolver's max cache TTL. On a cache hit
-// it is the remaining lifetime of the cached entry, so the value shrinks as the
-// entry ages. A TTL of 0 means the TTL is unknown, for example when the
-// upstream resolver does not provide one.
+// TXT resource records, capped by the resolver's max cache TTL ([WithMaxCacheTTL]).
+// On a cache hit it is the remaining lifetime of the cached entry, so the value
+// shrinks as the entry ages. A TTL of 0 means the records may not be cached:
+// because the cache is disabled ([WithCacheDisabled]), the records themselves
+// carry a TTL of 0, or the upstream resolver did not provide one.
 func (r *Resolver) LookupTXTWithTTL(ctx context.Context, domain string) ([]string, time.Duration, error) {
 	if result, ttl, ok := r.getCachedTXTWithTTL(domain); ok {
 		return result, ttl, nil
@@ -168,7 +169,7 @@ func (r *Resolver) getCachedIPAddr(domain string) ([]net.IPAddr, bool) {
 }
 
 func (r *Resolver) cacheIPAddr(domain string, ips []net.IPAddr, ttl time.Duration) {
-	if ttl == 0 {
+	if ttl <= 0 {
 		return
 	}
 
@@ -194,16 +195,19 @@ func (r *Resolver) getCachedTXTWithTTL(domain string) ([]string, time.Duration, 
 		return nil, 0, false
 	}
 
-	if time.Now().After(entry.expire) {
+	// Read the clock once: a second read after an expiry check could land
+	// past the deadline and report a negative TTL.
+	remaining := time.Until(entry.expire)
+	if remaining <= 0 {
 		delete(r.txtCache, fqdn)
 		return nil, 0, false
 	}
 
-	return entry.txt, time.Until(entry.expire), true
+	return entry.txt, remaining, true
 }
 
 func (r *Resolver) cacheTXT(domain string, txt []string, ttl time.Duration) {
-	if ttl == 0 {
+	if ttl <= 0 {
 		return
 	}
 

--- a/resolver.go
+++ b/resolver.go
@@ -106,6 +106,7 @@ func (r *Resolver) LookupIPAddr(ctx context.Context, domain string) (result []ne
 	}()
 
 	var ttl uint32
+	first := true
 	for i := 0; i < 2; i++ {
 		r := <-resch
 		if r.err != nil {
@@ -113,8 +114,13 @@ func (r *Resolver) LookupIPAddr(ctx context.Context, domain string) (result []ne
 		}
 
 		result = append(result, r.ips...)
-		if ttl == 0 || r.ttl < ttl {
+		// The combined TTL is the lowest across the A and AAAA answers that
+		// carried records; an empty answer has no RRset TTL to contribute, so
+		// its placeholder 0 must not zero out the other family's TTL. A
+		// genuine 0 from an existing RRset (do not cache) still wins.
+		if len(r.ips) > 0 && (first || r.ttl < ttl) {
 			ttl = r.ttl
+			first = false
 		}
 	}
 

--- a/resolver.go
+++ b/resolver.go
@@ -82,6 +82,11 @@ func NewResolver(url string, opts ...Option) (*Resolver, error) {
 
 var _ madns.BasicResolver = (*Resolver)(nil)
 
+// Consumers detect TXT TTL support through this optional interface at runtime,
+// so a signature drift would silently disable TTL reporting downstream; the
+// assertion makes it a compile error instead.
+var _ madns.TXTWithTTLResolver = (*Resolver)(nil)
+
 func (r *Resolver) LookupIPAddr(ctx context.Context, domain string) (result []net.IPAddr, err error) {
 	result, ok := r.getCachedIPAddr(domain)
 	if ok {

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -203,6 +203,100 @@ func TestLookupTXTWithTTLCappedByMaxCacheTTL(t *testing.T) {
 	}
 }
 
+func TestLookupTXTWithTTLCacheDisabled(t *testing.T) {
+	domain := "example.com"
+	resolver := mockDoHResolver(t, map[uint16]*dns.Msg{
+		dns.TypeTXT: mockDNSAnswerTXT(dns.Fqdn(domain), []string{"dnslink=/ipns/example.com"}),
+	})
+	defer resolver.Close()
+
+	// a disabled cache means nothing may be cached, so the reported TTL is 0
+	// no matter what the record says (300s in the mock)
+	r, err := NewResolver(resolver.URL, WithCacheDisabled())
+	if err != nil {
+		t.Fatal("resolver cannot be initialised")
+	}
+
+	txt, ttl, err := r.LookupTXTWithTTL(context.Background(), domain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(txt) == 0 {
+		t.Fatal("got no TXT entries")
+	}
+	if ttl != 0 {
+		t.Fatalf("expected ttl 0 with cache disabled, got %s", ttl)
+	}
+	if _, _, ok := r.getCachedTXTWithTTL(domain); ok {
+		t.Fatal("expected cache to stay empty")
+	}
+
+	// a nonsensical negative cap behaves like a disabled cache and is never
+	// reported as a negative TTL
+	rNeg, err := NewResolver(resolver.URL, WithMaxCacheTTL(-time.Second))
+	if err != nil {
+		t.Fatal("resolver cannot be initialised")
+	}
+
+	_, ttl, err = rNeg.LookupTXTWithTTL(context.Background(), domain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ttl != 0 {
+		t.Fatalf("expected ttl 0 with negative cap, got %s", ttl)
+	}
+	if _, _, ok := rNeg.getCachedTXTWithTTL(domain); ok {
+		t.Fatal("expected cache to stay empty with negative cap")
+	}
+}
+
+func mockDNSAnswerTXTWithTTLs(name string, ttls []uint32) *dns.Msg {
+	m := new(dns.Msg)
+	for _, ttl := range ttls {
+		m.Answer = append(m.Answer, &dns.TXT{
+			Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeTXT, Class: dns.ClassINET, Ttl: ttl},
+			Txt: []string{"dnslink=/ipns/example.com"},
+		})
+	}
+	return m
+}
+
+func TestLookupTXTWithTTLMixedTTLs(t *testing.T) {
+	// per RFC 2181 an RRset with differing TTLs is treated as having the
+	// lowest one, regardless of record order, and a genuine TTL 0 wins too
+	for _, tc := range []struct {
+		name     string
+		ttls     []uint32
+		expected time.Duration
+	}{
+		{"low first", []uint32{60, 300}, 60 * time.Second},
+		{"low last", []uint32{300, 60}, 60 * time.Second},
+		{"zero first", []uint32{0, 300}, 0},
+		{"zero last", []uint32{300, 0}, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			domain := "example.com"
+			resolver := mockDoHResolver(t, map[uint16]*dns.Msg{
+				dns.TypeTXT: mockDNSAnswerTXTWithTTLs(dns.Fqdn(domain), tc.ttls),
+			})
+			defer resolver.Close()
+
+			r, err := NewResolver(resolver.URL)
+			if err != nil {
+				t.Fatal("resolver cannot be initialised")
+			}
+
+			_, ttl, err := r.LookupTXTWithTTL(context.Background(), domain)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if ttl != tc.expected {
+				t.Fatalf("expected ttl %s, got %s", tc.expected, ttl)
+			}
+		})
+	}
+}
+
 func TestLookupCache(t *testing.T) {
 	domain := "example.com"
 	resolver := mockDoHResolver(t, map[uint16]*dns.Msg{

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -147,6 +147,62 @@ func TestLookupTXT(t *testing.T) {
 	}
 }
 
+func TestLookupTXTWithTTL(t *testing.T) {
+	domain := "example.com"
+	resolver := mockDoHResolver(t, map[uint16]*dns.Msg{
+		dns.TypeTXT: mockDNSAnswerTXT(dns.Fqdn(domain), []string{"dnslink=/ipns/example.com"}),
+	})
+	defer resolver.Close()
+
+	r, err := NewResolver(resolver.URL)
+	if err != nil {
+		t.Fatal("resolver cannot be initialised")
+	}
+
+	// cold lookup returns the record TTL from the answer (300s in the mock)
+	txt, ttl, err := r.LookupTXTWithTTL(context.Background(), domain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(txt) == 0 {
+		t.Fatal("got no TXT entries")
+	}
+	if ttl != 300*time.Second {
+		t.Fatalf("expected ttl 300s, got %s", ttl)
+	}
+
+	// warm lookup (cache hit) returns the remaining TTL, never more than the record TTL
+	_, ttl2, err := r.LookupTXTWithTTL(context.Background(), domain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ttl2 <= 0 || ttl2 > 300*time.Second {
+		t.Fatalf("expected remaining ttl in (0s, 300s], got %s", ttl2)
+	}
+}
+
+func TestLookupTXTWithTTLCappedByMaxCacheTTL(t *testing.T) {
+	domain := "example.com"
+	resolver := mockDoHResolver(t, map[uint16]*dns.Msg{
+		dns.TypeTXT: mockDNSAnswerTXT(dns.Fqdn(domain), []string{"dnslink=/ipns/example.com"}),
+	})
+	defer resolver.Close()
+
+	// record TTL (300s) is larger than the max cache TTL, so the returned TTL is capped
+	r, err := NewResolver(resolver.URL, WithMaxCacheTTL(10*time.Second))
+	if err != nil {
+		t.Fatal("resolver cannot be initialised")
+	}
+
+	_, ttl, err := r.LookupTXTWithTTL(context.Background(), domain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ttl != 10*time.Second {
+		t.Fatalf("expected ttl capped to 10s, got %s", ttl)
+	}
+}
+
 func TestLookupCache(t *testing.T) {
 	domain := "example.com"
 	resolver := mockDoHResolver(t, map[uint16]*dns.Msg{

--- a/resolver_test.go
+++ b/resolver_test.go
@@ -117,6 +117,34 @@ func TestLookupIPAddr(t *testing.T) {
 	}
 }
 
+func TestLookupIPAddrSingleFamily(t *testing.T) {
+	domain := "example.com"
+	resolver := mockDoHResolver(t, map[uint16]*dns.Msg{
+		dns.TypeA:    mockDNSAnswerA(dns.Fqdn(domain), net.IPv4(127, 0, 0, 1)),
+		dns.TypeAAAA: new(dns.Msg), // IPv4-only domain: empty AAAA answer
+	})
+	defer resolver.Close()
+
+	r, err := NewResolver(resolver.URL)
+	if err != nil {
+		t.Fatal("resolver cannot be initialised")
+	}
+
+	ips, err := r.LookupIPAddr(context.Background(), domain)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ips) != 1 {
+		t.Fatalf("expected 1 IP, got %d", len(ips))
+	}
+
+	// the empty AAAA answer carries no RRset TTL and must not zero out the A
+	// record's TTL (300s in the mock), so the result stays cacheable
+	if _, ok := r.getCachedIPAddr(domain); !ok {
+		t.Fatal("expected single-family result to be cached")
+	}
+}
+
 func TestLookupTXT(t *testing.T) {
 	domain := "example.com"
 	resolver := mockDoHResolver(t, map[uint16]*dns.Msg{

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.5.0"
+  "version": "v0.6.0"
 }

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.6.0"
+  "version": "v0.5.0"
 }


### PR DESCRIPTION
## Problem

`LookupTXT` computes the TXT record TTL (the smallest `Hdr.Ttl` across the answer) to size its internal cache, then throws it away before returning. Callers get the records but no indication of how long they are valid.

This blocks IPFS gateways from setting `Cache-Control: max-age=<ttl>` for DNSLink based on the DNS record's real TTL. DNSLink resolution flows through this resolver, but the TTL is lost at the `LookupTXT` boundary, so a `boxo/gateway` library (used by IPFS Desktop,  Kubo, Rainbow, ipfs.io etc) emits no `Cache-Control` for `/ipns/<dnslink-host>` responses and falls back to a static value. See ipfs/boxo#329 and the path-gateway spec's Cache-Control section [1]; tracked for Kubo under ipfs/kubo#8717.

## Fix

- Add `LookupTXTWithTTL(ctx, domain) ([]string, time.Duration, error)`, returning the records plus their TTL.
- `LookupTXT` now delegates to it, so its behavior is unchanged and the resolver still satisfies `madns.BasicResolver` (the new method is additive).
- On a cache hit, the returned TTL is the remaining lifetime of the cached entry, so it shrinks with age instead of over-reporting the original value.
- The TTL is capped by the resolver's max cache TTL (`WithMaxCacheTTL`); a TTL of `0` means unknown.

This lets consumers such as `boxo/namesys` thread the DNS TTL through to the gateway's `Cache-Control`. A follow-up boxo change will consume it via a new TTL-aware lookup option.

[1] https://specs.ipfs.tech/http-gateways/path-gateway/#cache-control-response-header