### PR TITLE
chore!: bump go.mod to Go 1.25 and run go fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/libp2p/go-doh-resolver
 
-go 1.24
+go 1.25
 
 require (
 	github.com/ipfs/go-log/v2 v2.5.1

--- a/resolver.go
+++ b/resolver.go
@@ -106,7 +106,7 @@ func (r *Resolver) LookupIPAddr(ctx context.Context, domain string) (result []ne
 	}()
 
 	var ttl uint32
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		r := <-resch
 		if r.err != nil {
 			return nil, r.err


### PR DESCRIPTION
release-check installs Go from master's go.mod, and gorelease no longer runs on 1.24; the madns v0.6.0 bump landing next requires Go 1.25 anyway.